### PR TITLE
fix encoding of since token if no new since is found

### DIFF
--- a/internal/snowflake_read.go
+++ b/internal/snowflake_read.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	gsf "github.com/snowflakedb/gosnowflake"
@@ -95,7 +96,7 @@ func (q *sfQuery) withSince(sinceColumn, sinceToken string) (query, error) {
 	row.Scan(&res)
 
 	if res == nil {
-		res = string(sinceVal)
+		res = strings.ReplaceAll(string(sinceVal), "'", "")
 	}
 
 	switch res.(type) {


### PR DESCRIPTION
if there is no new change since the last since token, then the `select MAX` query in the layer returns null. the layer logic then tries to re-use the value from the given since-token as max value. this leads to this invalid statement:

```
SELECT ID, NAME FROM db.schema.table
 WHERE sincecol > '2024-09-23T11:41:58+02:00'
     AND sincecol<= ''2024-09-23T11:41:58+02:00''
```