### PR TITLE
introduce latest_table: true source config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ To configure a dataset for writing, add a dataset definition to the configuratio
 Note that `source_config` is optional. If not provided here, the layer uses the dataset name as table,
 and database and schema from the environment variables `SNOWFLAKE_DB` and `SNOWFLAKE_SCHEMA`.
 
+As default, the layer will create a table with the name of the dataset, and *append* all entities to it.
+If a layer is configured with a `latest_table` flag set to true, the layer will additionally create a table with the
+name of the dataset and the suffix `_latest`. The layer will maintain the latest version of each entity in this table, using
+upserts. Note that the layer never deletes, deleted entities are marked by the deleted flag.
+
 ```javascript
 {
     "name": "name of the dataset (uri path)",
@@ -103,6 +108,7 @@ and database and schema from the environment variables `SNOWFLAKE_DB` and `SNOWF
         "table_name": "name of the table in snowflake",
         "schema": "name of the schema in snowflake",
         "database": "name of the database in snowflake"
+        "latest_table": false
     },
     "incoming_mapping_config": {
         "base_uri": "http://example.com",

--- a/internal/config.go
+++ b/internal/config.go
@@ -43,6 +43,7 @@ const (
 	Database    = "database"
 	RawColumn   = "raw_column"
 	SinceColumn = "since_column"
+	LatestTable = "latest_table"
 
 	// native system config
 	MemoryHeadroom      = "memory_headroom"

--- a/internal/snowflake.go
+++ b/internal/snowflake.go
@@ -90,3 +90,7 @@ func (sf *SfDB) close() error {
 func (sf *SfDB) newConnection(ctx context.Context) (*sql.Conn, error) {
 	return sf.db.Conn(ctx)
 }
+
+func (sf *SfDB) HasLatestActive(definition *common.DatasetDefinition) bool {
+	return definition.SourceConfig[LatestTable] != nil && definition.SourceConfig[LatestTable].(bool)
+}


### PR DESCRIPTION
closes #53.

users can now add the `"latest_table": true` option to a dataset's `source_config`. this will instruct the layer to write all changes to an upsert table called `<dataset>_latest`, in addition to the default append-only table.